### PR TITLE
인증 번호 이메일 전송 API에 이메일 중복 체크 기능 및 테스트 코드 추가

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/application.yml
+resources/
 
 ### STS ###
 .apt_generated

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'org.springframework.boot' version '2.6.2'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-	id 'org.asciidoctor.convert' version '1.5.8'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	id 'java'
 }
 
@@ -13,6 +13,7 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+    asciidoctorExt
 }
 
 repositories {
@@ -36,11 +37,11 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'ch.qos.logback:logback-classic:1.2.10'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.4'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
-	testImplementation 'org.assertj:assertj-core'
 }
 
 test {
@@ -49,6 +50,28 @@ test {
 }
 
 asciidoctor {
-	inputs.dir snippetsDir
-	dependsOn test
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+
+    attributes 'doctype': 'book',
+            'toclevels': '3',
+            'toc': 'left',
+            'source-highlighter': 'highlightjs',
+            'icons': 'font',
+            'sectlinks': ''
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/_/docs")
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/back/src/docs/asciidoc/accounts/email.adoc
+++ b/back/src/docs/asciidoc/accounts/email.adoc
@@ -1,0 +1,27 @@
+= 이메일 중복체크 및 인증번호 이메일 전송
+
+== Errors
+=== 400 Bad Request
+- 잘못된 요청으로 인한 이메일 전송 실패
+
+----
+{
+  "message" : "에러 메시지",
+  "code" : "에러 코드",
+  "errors" : [
+    {
+    "field" : "에러가 발생한 변수명",
+    "value" : "에러가 발생한 변수의 값",
+    "reason" : "에러 발생 이유"
+    },
+    ...
+  ]
+}
+----
+
+=== 500 Internal Server Error
+- 서버 오류
+
+== Success
+
+operation::accounts/email[snippets='curl-request,request-fields,request-body,http-request,http-response']

--- a/back/src/docs/asciidoc/api-docs.adoc
+++ b/back/src/docs/asciidoc/api-docs.adoc
@@ -1,0 +1,4 @@
+= 덕구 API 문서
+
+=== Account
+1. <<accounts/email.adoc#, 이메일 중복체크 및 인증번호 이메일 전송>>

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/controller/AccountController.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/controller/AccountController.java
@@ -26,9 +26,9 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping("/email")
-    @Operation(summary = "인증번호 이메일 전송", description = "인증번호를 담은 이메일을 전송합니다.", responses = {
+    @Operation(summary = "이메일 중복체크 및 인증번호 이메일 전송", description = "이메일의 중복을 체크하고, 인증번호를 담은 이메일을 전송합니다.", responses = {
             @ApiResponse(responseCode = "200", description = "인증번호 이메일 전송 성공"),
-            @ApiResponse(responseCode = "400", description = "인증번호 이메일 전송 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "이메일 중복 혹은 인증번호 이메일 전송 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<Void> emailAuthentication(@Valid @RequestBody EmailAuthRequest emailAuthRequest) {

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/domain/Account.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/domain/Account.java
@@ -1,7 +1,42 @@
 package com.doghandeveloper.doggu.Account.domain;
 
-import javax.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
-//@Entity
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class Account {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String username;
+
+    private String password;
+
+    @Lob
+    private String introduction;
+
+    //TODO: 범석오빠가 커밋하면 abstract class로 변경
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+
+    @Builder
+    public Account(String email, String username, String password, String introduction) {
+        this.email = email;
+        this.username = username;
+        this.password = password;
+        this.introduction = introduction;
+    }
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/dto/request/EmailAuthRequest.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/dto/request/EmailAuthRequest.java
@@ -15,9 +15,9 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailAuthRequest {
     @Schema(description = "인증 번호 전송용 이메일", example = "abcd1234@naver.com")
-    @Email
+    @Email(message = "이메일 형식이 아닙니다.")
     @Length(max = 100, message = "이메일은 100자 이하로 입력해주세요.")
-    @NotBlank
+    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
 
     @Builder

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/dto/request/EmailAuthRequest.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/dto/request/EmailAuthRequest.java
@@ -2,6 +2,7 @@ package com.doghandeveloper.doggu.Account.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -18,4 +19,9 @@ public class EmailAuthRequest {
     @Length(max = 100, message = "이메일은 100자 이하로 입력해주세요.")
     @NotBlank
     private String email;
+
+    @Builder
+    public EmailAuthRequest(String email) {
+        this.email = email;
+    }
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/repository/AccountRepository.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/repository/AccountRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
+    boolean existsByEmail(String email);
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/service/AccountServiceImpl.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/service/AccountServiceImpl.java
@@ -1,6 +1,9 @@
 package com.doghandeveloper.doggu.Account.service;
 
+import com.doghandeveloper.doggu.Account.repository.AccountRepository;
 import com.doghandeveloper.doggu.common.config.EmailProperties;
+import com.doghandeveloper.doggu.common.exception.AuthException;
+import com.doghandeveloper.doggu.common.exception.dto.ErrorCode;
 import com.doghandeveloper.doggu.common.utils.EmailSendUtil;
 import com.doghandeveloper.doggu.common.utils.RedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +15,15 @@ import java.util.UUID;
 @Service
 public class AccountServiceImpl implements AccountService {
 
-//    private final AccountRepository accountRepository;
+    private final AccountRepository accountRepository;
     private final EmailSendUtil emailSendUtil;
     private final RedisUtil redisUtil;
 
     @Override
     public void sendEmail(String email) {
+        if (accountRepository.existsByEmail(email)) {
+            throw new AuthException(ErrorCode.DUPLICATED_EMAIL);
+        }
         final String authCode = createCode();
         EmailProperties properties = EmailProperties.SIGNUP_EMAIL_AUTH;
         emailSendUtil.sendEmail(email, properties.getSubject(), String.format(properties.getTextFormat(), authCode));

--- a/back/src/main/java/com/doghandeveloper/doggu/common/exception/AuthException.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/common/exception/AuthException.java
@@ -1,0 +1,9 @@
+package com.doghandeveloper.doggu.common.exception;
+
+import com.doghandeveloper.doggu.common.exception.dto.ErrorCode;
+
+public class AuthException extends CustomException{
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/back/src/main/java/com/doghandeveloper/doggu/common/exception/CustomException.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/common/exception/CustomException.java
@@ -1,4 +1,12 @@
 package com.doghandeveloper.doggu.common.exception;
 
-public class CustomException {
+import com.doghandeveloper.doggu.common.exception.dto.ErrorCode;
+
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/common/exception/dto/ErrorCode.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/common/exception/dto/ErrorCode.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "EN_001", "올바르지 않은 요청 값입니다."),
 
-    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "ES_001", "인증번호 이메일 전송이 실패했습니다.")
-    ;
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST.value(), "AU_001", "이미 존재하는 이메일입니다."),
+
+    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "ES_001", "인증번호 이메일 전송이 실패했습니다.");
     private final int status;
     private final String code;
     private final String message;

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/controller/AccountControllerTest.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/controller/AccountControllerTest.java
@@ -1,0 +1,53 @@
+package com.doghandeveloper.doggu.Account.controller;
+
+import com.doghandeveloper.doggu.Account.controller.docs.AccountDocumentation;
+import com.doghandeveloper.doggu.Account.dto.request.EmailAuthRequest;
+import com.doghandeveloper.doggu.Account.service.AccountService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = AccountController.class)
+@AutoConfigureRestDocs
+class AccountControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AccountService accountService;
+
+    @Test
+    @DisplayName("인증번호 이메일 발송 성공")
+    void emailAuthenticationSuccess() throws Exception {
+        EmailAuthRequest emailAuthRequest = EmailAuthRequest.builder()
+                .email("doggu@gmail.com")
+                .build();
+
+        mockMvc.perform(post("/accounts/email")
+                        .content(objectMapper.writeValueAsString(emailAuthRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(AccountDocumentation.emailAuthentication());
+    }
+
+}

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/controller/docs/AccountDocumentation.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/controller/docs/AccountDocumentation.java
@@ -1,0 +1,20 @@
+package com.doghandeveloper.doggu.Account.controller.docs;
+
+import com.doghandeveloper.doggu.common.utils.ApiDocumentUtils;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+
+public class AccountDocumentation {
+    public static RestDocumentationResultHandler emailAuthentication() {
+        return document("accounts/email",
+                ApiDocumentUtils.getDocumentRequest(),
+                ApiDocumentUtils.getDocumentResponse(),
+                requestFields(
+                        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+                ));
+    }
+}

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/dto/request/EmailAuthRequestTest.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/dto/request/EmailAuthRequestTest.java
@@ -1,0 +1,62 @@
+package com.doghandeveloper.doggu.Account.dto.request;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class EmailAuthRequestTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    @DisplayName("올바른 이메일로 인증 요청을 보낸다.")
+    void emailAuthRequestWithCorrectEmail() {
+        String email = "abcd1234@gmail.com";
+        EmailAuthRequest emailAuthRequest = EmailAuthRequest.builder().email(email).build();
+
+        Set<ConstraintViolation<EmailAuthRequest>> validate = validator.validate(emailAuthRequest);
+
+        List<String> messages = validate.stream().map(ConstraintViolation::getMessage).collect(Collectors.toList());
+
+        Assertions.assertThat(messages).size().isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 이메일로 인증 요청을 보낼 수 없다.")
+    void emailAuthRequestWithWrongEmail() {
+        String email = " ";
+        EmailAuthRequest emailAuthRequest = EmailAuthRequest.builder().email(email).build();
+
+        Set<ConstraintViolation<EmailAuthRequest>> validate = validator.validate(emailAuthRequest);
+
+        List<String> messages = validate.stream().map(ConstraintViolation::getMessage).collect(Collectors.toList());
+
+        Assertions.assertThat(messages).contains("이메일 형식이 아닙니다.", "이메일은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("너무 긴 이메일로 인증 요청을 보낼 수 없다.")
+    void emailAuthRequestWithTooLongEmail() {
+        String email = "abcdefghijklmnopqlstuvwxyzabcdefghijklmnopqlstuvwxyzabcdefghijklmnopqlstuvwxyzabcdefghijklmnopqlstuvwxyz@gmail.com";
+        EmailAuthRequest emailAuthRequest = EmailAuthRequest.builder().email(email).build();
+
+        Set<ConstraintViolation<EmailAuthRequest>> validate = validator.validate(emailAuthRequest);
+
+        List<String> messages = validate.stream().map(ConstraintViolation::getMessage).collect(Collectors.toList());
+
+        Assertions.assertThat(messages).contains("이메일은 100자 이하로 입력해주세요.");
+    }
+}

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/service/AccountServiceImplTest.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/service/AccountServiceImplTest.java
@@ -1,0 +1,56 @@
+package com.doghandeveloper.doggu.Account.service;
+
+import com.doghandeveloper.doggu.Account.repository.AccountRepository;
+import com.doghandeveloper.doggu.common.exception.AuthException;
+import com.doghandeveloper.doggu.common.utils.EmailSendUtil;
+import com.doghandeveloper.doggu.common.utils.RedisUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountServiceImplTest {
+
+    @InjectMocks
+    private AccountServiceImpl accountService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private EmailSendUtil emailSendUtil;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Test
+    @DisplayName("인증메일을 성공적으로 보낸다.")
+    void sendEmail() {
+        emailSendUtil.sendEmail(anyString(),anyString(),anyString());
+        redisUtil.setDataExpire(anyString(),anyString(),anyLong());
+
+        verify(emailSendUtil).sendEmail(anyString(),anyString(),anyString());
+        verify(redisUtil).setDataExpire(anyString(),anyString(),anyLong());
+    }
+
+    @Test
+    @DisplayName("중복된 이메일로 인증메일을 보낼 수 없다.")
+    void sendEmailToDuplicatedEmail() {
+        String email = "doggu@gmail.com";
+
+        when(accountRepository.existsByEmail(email)).thenReturn(true);
+
+        assertThatThrownBy(() -> accountService.sendEmail(email))
+                .isInstanceOf(AuthException.class)
+                .hasMessageContainingAll("존재하는 이메일");
+    }
+}

--- a/back/src/test/java/com/doghandeveloper/doggu/common/utils/ApiDocumentUtils.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/common/utils/ApiDocumentUtils.java
@@ -1,0 +1,23 @@
+package com.doghandeveloper.doggu.common.utils;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+public interface ApiDocumentUtils {
+
+    static OperationRequestPreprocessor getDocumentRequest(){
+        return preprocessRequest(
+                modifyUris()
+                        .scheme("https")
+                        .host("doggu.kr")
+                        .removePort(),
+                prettyPrint()
+        );
+    }
+
+    static OperationResponsePreprocessor getDocumentResponse(){
+        return preprocessResponse(prettyPrint());
+    }
+}

--- a/back/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,11 @@
+|===
+|필드명|타입|설명|필수여부
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}✔{{/optional}}{{/tableCellContent}}
+{{/fields}}
+
+|===


### PR DESCRIPTION
## 목적
- 이메일 인증을 위한 인증 번호 이메일을 보내기 전 이메일 중복 여부를 확인한다.
- API의 테스트 코드를 추가한다.

## 작업 상세 내용
- [X] [DOG-96] RestDocs 설정
- [X] [DOG-64] 이메일 인증번호 전송 Controller 테스트 코드 작성
- [x] [DOG-65] 이메일 인증번호 전송 Service 테스트 코드 작성
- [x] [DOG-72] 이메일 인증번호 전송 DTO 테스트 코드 작성
- [X] [DOG-105] 이메일 중복 체크 기능 추가 
  - Account Domain 생성
  - Account Reposioty 생성







[DOG-96]: https://dog-han-developer.atlassian.net/browse/DOG-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-64]: https://dog-han-developer.atlassian.net/browse/DOG-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-65]: https://dog-han-developer.atlassian.net/browse/DOG-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-105]: https://dog-han-developer.atlassian.net/browse/DOG-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOG-72]: https://dog-han-developer.atlassian.net/browse/DOG-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ