### PR TITLE
이름 중복 체크 API 개발

### DIFF
--- a/back/src/docs/asciidoc/accounts/duplicate/{username}.adoc
+++ b/back/src/docs/asciidoc/accounts/duplicate/{username}.adoc
@@ -1,0 +1,27 @@
+= 사용자 이름 중복 체크
+
+== Errors
+=== 400 Bad Request
+- 잘못된 요청으로 인한 이메일 인증번호 확인 실패
+
+----
+{
+  "message" : "에러 메시지",
+  "code" : "에러 코드",
+  "errors" : [
+    {
+    "field" : "에러가 발생한 변수명",
+    "value" : "에러가 발생한 변수의 값",
+    "reason" : "에러 발생 이유"
+    },
+    ...
+  ]
+}
+----
+
+=== 500 Internal Server Error
+- 서버 오류
+
+== Success
+
+operation::accounts/duplicate/{username}[snippets='curl-request,path-parameters,http-request,http-response']

--- a/back/src/docs/asciidoc/accounts/email/verify.adoc
+++ b/back/src/docs/asciidoc/accounts/email/verify.adoc
@@ -1,0 +1,27 @@
+= 이메일 인증번호 확인
+
+== Errors
+=== 400 Bad Request
+- 잘못된 요청으로 인한 이메일 인증번호 확인 실패
+
+----
+{
+  "message" : "에러 메시지",
+  "code" : "에러 코드",
+  "errors" : [
+    {
+    "field" : "에러가 발생한 변수명",
+    "value" : "에러가 발생한 변수의 값",
+    "reason" : "에러 발생 이유"
+    },
+    ...
+  ]
+}
+----
+
+=== 500 Internal Server Error
+- 서버 오류
+
+== Success
+
+operation::accounts/email/verify[snippets='curl-request,request-fields,request-body,http-request,http-response']

--- a/back/src/docs/asciidoc/api-docs.adoc
+++ b/back/src/docs/asciidoc/api-docs.adoc
@@ -2,3 +2,5 @@
 
 === Account
 1. <<accounts/email.adoc#, 이메일 중복체크 및 인증번호 이메일 전송>>
+2. <<accounts/email/verify.adoc#, 이메일 인증번호 확인>>
+3. <<accounts/duplicate/{username}.adoc#, 사용자 이름 중복 체크>>

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/controller/AccountController.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/controller/AccountController.java
@@ -9,9 +9,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Slf4j
 @RestController
-@RequestMapping("/accounts")
+@RequestMapping("/accounts/")
 public class AccountController {
 
     private final AccountService accountService;
 
-    @PostMapping("/email")
+    @PostMapping("email")
     @Operation(summary = "이메일 중복체크 및 인증번호 이메일 전송", description = "이메일의 중복을 체크하고, 인증번호를 담은 이메일을 전송합니다.", responses = {
         @ApiResponse(responseCode = "200", description = "인증번호 이메일 전송 성공"),
         @ApiResponse(responseCode = "400", description = "이메일 중복 혹은 인증번호 이메일 전송 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -37,15 +40,30 @@ public class AccountController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping ("/email/verify")
+    @PostMapping("email/verify")
     @Operation(summary = "이메일 인증번호 확인", description = "이메일로 전송받은 인증번호를 확인합니다.", responses = {
         @ApiResponse(responseCode = "200", description = "인증번호 확인 성공"),
         @ApiResponse(responseCode = "400", description = "인증번호 확인 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<Void> verifyEmailAuthentication(@Valid @RequestBody AuthEmailVerifyRequest authEmailVerifyRequest) {
-        accountService.verifyAuthenticationCode(authEmailVerifyRequest.getEmail(),authEmailVerifyRequest.getAuthenticationCode());
+        accountService.verifyAuthenticationCode(authEmailVerifyRequest.getEmail(), authEmailVerifyRequest.getAuthenticationCode());
         log.info("이메일 인증번호 확인 성공: {}", authEmailVerifyRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("duplicate/{username}")
+    @Operation(summary = "사용자 이름 중복 체크", description = "사용자 이름의 중복을 체크합니다.", responses = {
+        @ApiResponse(responseCode = "200", description = "사용자 이름 중복 체크 성공"),
+        @ApiResponse(responseCode = "400", description = "사용자 이름 중복 체크 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> verifyDuplicateUsername(
+        @Pattern(regexp = "^[a-z0-9_\\.]*$", message = "사용자 이름은 영어(소문자), 숫자, _, .만 사용 가능합니다.")
+        @PathVariable String username
+    ) {
+        accountService.verifyDuplicateUsername(username);
+        log.info("사용자 이름 중복 체크 성공: {}", username);
         return ResponseEntity.ok().build();
     }
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/domain/Account.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/domain/Account.java
@@ -16,8 +16,10 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String email;
 
+    @Column(unique = true)
     private String username;
 
     private String password;

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/repository/AccountRepository.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/repository/AccountRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
     boolean existsByEmail(String email);
+
+    boolean existsByUsername(String username);
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/service/AccountService.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/service/AccountService.java
@@ -4,4 +4,6 @@ public interface AccountService {
     void sendEmail(String email);
 
     void verifyAuthenticationCode(String authenticationCode, String code);
+
+    void verifyDuplicateUsername(String userName);
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/Account/service/AccountServiceImpl.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/Account/service/AccountServiceImpl.java
@@ -43,4 +43,11 @@ public class AccountServiceImpl implements AccountService {
             throw new InvalidParameterException();
         }
     }
+
+    @Override
+    public void verifyDuplicateUsername(String username) {
+        if(accountRepository.existsByUsername(username)){
+            throw new AuthException(ErrorCode.DUPLICATED_EMAIL);
+        }
+    }
 }

--- a/back/src/main/java/com/doghandeveloper/doggu/common/exception/dto/ErrorCode.java
+++ b/back/src/main/java/com/doghandeveloper/doggu/common/exception/dto/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "EN_001", "올바르지 않은 요청 값입니다."),
 
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST.value(), "AU_001", "이미 존재하는 이메일입니다."),
+    DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST.value(), "AU_002", "이미 존재하는 사용자 이름입니다."),
 
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "ES_001", "인증번호 이메일 전송이 실패했습니다.");
     private final int status;

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/controller/AccountControllerTest.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/controller/AccountControllerTest.java
@@ -1,5 +1,9 @@
 package com.doghandeveloper.doggu.Account.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.doghandeveloper.doggu.Account.controller.docs.AccountDocumentation;
 import com.doghandeveloper.doggu.Account.dto.request.AuthEmailSendRequest;
 import com.doghandeveloper.doggu.Account.dto.request.AuthEmailVerifyRequest;
@@ -13,12 +17,9 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = AccountController.class)
@@ -35,8 +36,8 @@ class AccountControllerTest {
     private AccountService accountService;
 
     @Test
-    @DisplayName("인증번호 이메일 발송 성공")
-    void sendAuthenticationEmailSuccess() throws Exception {
+    @DisplayName("인증번호 이메일 발송")
+    void sendAuthenticationEmail() throws Exception {
         AuthEmailSendRequest authEmailSendRequest = AuthEmailSendRequest.builder()
             .email("doggu@gmail.com")
             .build();
@@ -52,8 +53,8 @@ class AccountControllerTest {
     }
 
     @Test
-    @DisplayName("이메일 인증번호 확인 성공")
-    void verifyAuthenticationCodeSuccess() throws Exception {
+    @DisplayName("이메일 인증번호 확인")
+    void verifyAuthenticationCode() throws Exception {
         AuthEmailVerifyRequest authEmailVerifyRequest = AuthEmailVerifyRequest.builder()
             .email("doggu@gmail.com")
             .authenticationCode("2b0a8a4d-a27f-4d01-b031-2a003cc4c039")
@@ -67,5 +68,18 @@ class AccountControllerTest {
             .andExpect(status().isOk())
             .andDo(print())
             .andDo(AccountDocumentation.verifyAuthenticationCode());
+    }
+
+    @Test
+    @DisplayName("사용자 이름 중복 체크")
+    void verifyDuplicateUsername() throws Exception {
+        String username = "doggu_love";
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/accounts/duplicate/{username}", username)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+            )
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andDo(AccountDocumentation.verifyDuplicateUserName());
     }
 }

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/controller/docs/AccountDocumentation.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/controller/docs/AccountDocumentation.java
@@ -1,21 +1,26 @@
 package com.doghandeveloper.doggu.Account.controller.docs;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+
 import com.doghandeveloper.doggu.common.utils.ApiDocumentUtils;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-
 public class AccountDocumentation {
+
     public static RestDocumentationResultHandler sendAuthenticationEmail() {
         return document("accounts/email",
-                ApiDocumentUtils.getDocumentRequest(),
-                ApiDocumentUtils.getDocumentResponse(),
-                requestFields(
-                        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
-                ));
+            ApiDocumentUtils.getDocumentRequest(),
+            ApiDocumentUtils.getDocumentResponse(),
+            requestFields(
+                fieldWithPath("email")
+                    .type(JsonFieldType.STRING)
+                    .description("이메일")
+            ));
     }
 
     public static RestDocumentationResultHandler verifyAuthenticationCode() {
@@ -23,8 +28,23 @@ public class AccountDocumentation {
             ApiDocumentUtils.getDocumentRequest(),
             ApiDocumentUtils.getDocumentResponse(),
             requestFields(
-                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-                fieldWithPath("authenticationCode").type(JsonFieldType.STRING).description("인증번호")
+                fieldWithPath("email")
+                    .type(JsonFieldType.STRING)
+                    .description("이메일"),
+                fieldWithPath("authenticationCode")
+                    .type(JsonFieldType.STRING)
+                    .description("인증번호")
             ));
+    }
+
+    public static RestDocumentationResultHandler verifyDuplicateUserName() {
+        return document("accounts/duplicate/{username}",
+            ApiDocumentUtils.getDocumentRequest(),
+            ApiDocumentUtils.getDocumentResponse(),
+            pathParameters(
+                parameterWithName("username")
+                    .description("사용자 이름")
+            )
+        );
     }
 }

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/dto/request/VerifyDuplicateUsernameRequestTest.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/dto/request/VerifyDuplicateUsernameRequestTest.java
@@ -1,0 +1,27 @@
+package com.doghandeveloper.doggu.Account.dto.request;
+
+import java.util.regex.Pattern;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class VerifyDuplicateUsernameRequestTest {
+
+    private final static String PATTERN = "^[a-z0-9_\\.]*$";
+
+    @Test
+    @DisplayName("올바른 사용자 이름으로 중복 확인을 요청한다.")
+    void withCorrectUsername(){
+        String username = "doggu_love1234.png";
+
+        Assertions.assertThat(Pattern.matches(PATTERN, username)).isTrue();
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 사용자 이름으로 중복 확인을 요청할 수 없다.")
+    void withWrongUsername(){
+        String username = "doggu#love";
+
+        Assertions.assertThat(Pattern.matches(PATTERN, username)).isFalse();
+    }
+}

--- a/back/src/test/java/com/doghandeveloper/doggu/Account/service/AccountServiceImplTest.java
+++ b/back/src/test/java/com/doghandeveloper/doggu/Account/service/AccountServiceImplTest.java
@@ -66,8 +66,6 @@ class AccountServiceImplTest {
 
         when(redisUtil.getData(email)).thenReturn(authenticationCode);
 
-        accountService.verifyAuthenticationCode(email, authenticationCode);
-
         assertDoesNotThrow(() -> accountService.verifyAuthenticationCode(email, authenticationCode));
     }
 
@@ -94,5 +92,15 @@ class AccountServiceImplTest {
 
         assertThatThrownBy(() -> accountService.verifyAuthenticationCode(email, authenticationCode))
             .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    @DisplayName("사용자 이름이 중복되지 않았는지 확인한다.")
+    void verifyDuplicateUsername() {
+        String username = "doggu_love";
+
+        when(accountRepository.existsByUsername(username)).thenReturn(false);
+
+        assertDoesNotThrow(() -> accountService.verifyDuplicateUsername(username));
     }
 }


### PR DESCRIPTION
## 목적
- 이름이 중복되었는지 확인한다.

## 작업 상세 내용
- [x] [DOG-42] 회원 Domain 개발
- 지난 커밋에서 이미 domain을 개발했기 때문에, 이번 수정에서는 unique key만 추가해주었습니다.
- [x] [DOG-39] Controller에 이름 중복 체크 API 개발
- 각 url마다 앞에 붙어있던 /를 제거해주고, 공통 url의 뒤에 /를 붙였습니다.
- [x] [DOG-40] Service에 이름 중복 체크 기능 개발
- [x] [DOG-45] 이미 존재하는 이름인지 체크하는 Repository 개발
- [x] [DOG-69] 사용자 이름 중복 체크 Controller 테스트 코드 작성
- [x] [DOG-70] 사용자 이름 중복 체크 Service 테스트 코드 작성
- [x] [DOG-77] 사용자 이름 중복 체크 DTO 테스트 코드 작성

[DOG-42]: https://dog-han-developer.atlassian.net/browse/DOG-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-39]: https://dog-han-developer.atlassian.net/browse/DOG-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-40]: https://dog-han-developer.atlassian.net/browse/DOG-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-45]: https://dog-han-developer.atlassian.net/browse/DOG-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-69]: https://dog-han-developer.atlassian.net/browse/DOG-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-70]: https://dog-han-developer.atlassian.net/browse/DOG-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOG-77]: https://dog-han-developer.atlassian.net/browse/DOG-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ